### PR TITLE
Fixes #9, Maximum call stack size exceeded: due to computed.reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ In addition to all the features supported by `aupac-typeahead` (see below), `aup
 -  `displayKey` : (default: 'displayName') the attribute to display to the user when an item is selected,
 -  `params` : (default: {}) an object containing various query string parameters to send along with the remote request,
 -  `queryKey`: (default: 'q') the query parameter sent to the server containing the search text.
--  `selection` : (default: null) initial selection - can be an `ember-data` model (in which case the `displayKey` is used as the initial value) or a `string` which will display as is.
+-  `selection` : (default: null) initial selection - can be an `ember-data` model (in which case the `displayKey` is used as the initial value) or a `string` which will display as is. Wrap selection in `(readonly x)` helper to avoid two-way binding.
 
 This component has already implemented the `source`, `setValue` and `display` functions to make them compatible with ember-data.  You do not need to do so yourself.
 
@@ -52,7 +52,7 @@ The `aupac-typeahead` component contains no assumptions about how you're retriev
 -  `placeholder` : (default: 'Search') the placeholder text to display in the input.
 -  `name` : (default: '') the name of the typeahead input.
 -  `action`: (*required) the selected item will be provided as the first argument.
--  `selection` : (default: null) will be set as the initial selection in the component.
+-  `selection` : (default: null) will be set as the initial selection in the component. Wrap selection with helper `(readonly x)` to avoid two-way binding. 
 -  `autoFocus`: (default: false) focus the control on render.
 -  `setValue`: (default: sets the value as is) a function to set the typeahead value based on the users `selection`, signature `function(selection)`.
     

--- a/addon/components/aupac-ember-data-typeahead.js
+++ b/addon/components/aupac-ember-data-typeahead.js
@@ -85,8 +85,8 @@ export default AupacTypeahead.extend({
   /**
    * @Override
    */
-  selectionUpdated : observer('_selection.id', '_typeahead', function() {
-    const selection = this.get('_selection');
+  selectionUpdated : observer('selection.id', '_typeahead', function() {
+    const selection = this.get('selection');
     if(isNone(selection)) {
       this.setValue(null);
     } else {

--- a/addon/components/aupac-typeahead.js
+++ b/addon/components/aupac-typeahead.js
@@ -46,9 +46,6 @@ export default Component.extend({
   //Private
   _typeahead: null,
 
-  // shadow the passed-in `selection` to avoid
-  // leaking changes to it via a 2-way binding
-  _selection: computed.reads('selection'),
 
   /**
    * @public
@@ -144,12 +141,12 @@ export default Component.extend({
 
     // Set selected object
     t.on('typeahead:autocompleted', run.bind(this, (jqEvent, suggestionObject /*, nameOfDatasetSuggestionBelongsTo*/) => {
-      this.set('_selection', suggestionObject);
+      this.set('selection', suggestionObject);
       this.sendAction('action', suggestionObject);
     }));
 
     t.on('typeahead:selected', run.bind(this, (jqEvent, suggestionObject /*, nameOfDatasetSuggestionBelongsTo*/) => {
-      this.set('_selection', suggestionObject);
+      this.set('selection', suggestionObject);
       this.sendAction('action', suggestionObject);
     }));
 
@@ -159,7 +156,7 @@ export default Component.extend({
       if (jqEvent.which === Key.BACKSPACE || jqEvent.which === Key.DELETE) {
         debug("Removing model");
         const value = this.get('_typeahead').typeahead('val'); //cache value
-        this.set('_selection', null);
+        this.set('selection', null);
         this.sendAction('action', null);
         this.setValue(value); //restore the text, thus allowing the user to make corrections
       }
@@ -167,7 +164,7 @@ export default Component.extend({
 
     t.on('focusout', run.bind(this, (/*jqEvent*/) => {
       //the user has now left the control, update display with current binding or reset to blank
-      const model = this.get('_selection');
+      const model = this.get('selection');
       if (model) {
         this.setValue(model);
       } else {
@@ -177,16 +174,9 @@ export default Component.extend({
 
   },
 
-  // Fix weird bug whereby changing the bound selection to null would not fire "selectionUpdated"
-  boundSelectionUpdated: observer('selection',function() {
-    const selection = this.get('selection');
-    if(isNone(selection)) {
-      this.set('_selection', null);
-    }
-  }),
 
-  selectionUpdated: observer('_selection', '_typeahead',function() {
-    const selection = this.get('_selection');
+  selectionUpdated: observer('selection', '_typeahead',function() {
+    const selection = this.get('selection');
     if(isNone(selection)) {
       this.setValue(null);
     } else {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -82,7 +82,7 @@
             <button class="btn btn-default" {{action 'clearModel'}}>Clear Model</button>
             {{#aupac-control label="Task" mandatory=true errors=errors.task leftIcon="glyphicon glyphicon-search"}}
               {{aupac-ember-data-typeahead action=(action (mut task))
-              selection=task.displayName
+              selection=(readonly task.displayName)
               class='form-control'
               modelClass='task'
               placeholder='Type task...'


### PR DESCRIPTION
This fixes call stack issue in ember 2.2.

We now have `(readonly )` helper in ember, so we can use that instead - and when angle bracket components that readonly is not necessary.
