### PR TITLE
setValue fix and press "Enter" key handling

### DIFF
--- a/addon/components/aupac-ember-data-typeahead.js
+++ b/addon/components/aupac-ember-data-typeahead.js
@@ -27,10 +27,15 @@ export default AupacTypeahead.extend({
     };
   }),
 
+  setValueOverride(selection){
+      return selection;
+  },
+
   /**
    * @Override
    */
   setValue : function(selection) {
+    selection = this.setValueOverride(selection);
     if (typeof selection === 'string') {
       this.get('_typeahead').typeahead('val', selection);
     } else {

--- a/addon/components/aupac-typeahead.js
+++ b/addon/components/aupac-typeahead.js
@@ -9,7 +9,8 @@ const {observer, isNone, run, debug, Component} = Ember;
 
 const Key = {
   BACKSPACE : 8,
-  DELETE : 46
+  DELETE : 46,
+  ENTER : 13
 };
 
 export default Component.extend({
@@ -160,6 +161,9 @@ export default Component.extend({
         this.set('selection', null);
         this.sendAction('action', null);
         this.setValue(value); //restore the text, thus allowing the user to make corrections
+      }
+      else if (jqEvent.which === Key.ENTER) {
+          t.trigger( "focusout" );
       }
     }));
 


### PR DESCRIPTION
1) When enter is pressed do the same thing as when focus is lost. It is useful for allowFreeInput=true when you want to press enter and save/handle the search result

2) setValue parameter is not working now, there is no way to overwrite the component's value from the Controller.
I suggest to replace it with "setValueOverride=someMethodName" and with these fixes it will work just fine.
