### PR TITLE
you shouldn't reference jQuery with $

### DIFF
--- a/addon/components/aupac-ember-data-typeahead.js
+++ b/addon/components/aupac-ember-data-typeahead.js
@@ -71,7 +71,7 @@ export default AupacTypeahead.extend({
     return function (query, syncResults, asyncResults) {
       const q = {};
       q[_this.get('queryKey')] = query;
-      const queryObj = $.extend(true, {}, q , _this.get('params'));
+      const queryObj = jQuery.extend(true, {}, q , _this.get('params'));
 
       _this.get('store').query(_this.get('modelClass'), queryObj).then(function(models) {
         let emberDataModels = [];


### PR DESCRIPTION
In 99% of all cases this won't cause any problems as jQuery is mostly build together with your ember application, and is referenced with $, however, in cases where jQuery is excluded from the build, and you rely on jQuery to be manually loaded, $ isn't always used as a jQuery reference.
