### PR TITLE
Perform More Thorough Cleanup

### DIFF
--- a/addon/components/aupac-typeahead.js
+++ b/addon/components/aupac-typeahead.js
@@ -203,7 +203,21 @@ export default Component.extend({
 
   willDestroyElement : function() {
     this._super(...arguments);
+    let t = this.get('_typeahead');
+
+    //Remove custom event handlers before destroying
+    t.off('typeahead:autocompleted');
+    t.off('typeahead:selected');
+    t.off('keyup');
+    t.off('focusout');
+
+    //While this wasn't set explicitly here, heap traces indicate a hanging handler
+    t.off('keydown');
+
     this.get('_typeahead').typeahead('destroy');
+
+    //Dereference the element
+    this.set('_typeahead', null);
   }
 
 });


### PR DESCRIPTION
While debugging a large Ember application, I noticed that our typeahead was leaking memory. As it turned out, there were event handlers registered in jQuery that weren't properly removed when the component was destroyed.

This PR removes those event handlers and also dereferences the typeahead after it is destroyed so that garbage collection occurs properly.
