### PR TITLE
Update aupac-typeahead.js

### DIFF
--- a/addon/components/aupac-typeahead.js
+++ b/addon/components/aupac-typeahead.js
@@ -71,7 +71,7 @@ export default Component.extend({
    * @param selection the item selected by the user
    */
   setValue : function(selection) {
-    selection = this.transformSelection(selection);
+    selection = this.get('transformSelection')(selection);
     if(selection) {
       this.get('_typeahead').typeahead('val', selection);
     } else {


### PR DESCRIPTION
transformSelection could be a computed property.
In my case I extended this component where transformSelection was a computed property which returned a function, hence ~this.transformSelection~ was breaking.
