### PR TITLE
Use correct selector for finding suggestions in test helper

### DIFF
--- a/test-support/helpers/aupac-typeahead.js
+++ b/test-support/helpers/aupac-typeahead.js
@@ -17,7 +17,7 @@ export default function() {
         $(selector).eq(0).val(searchString).trigger("input");
 
         Ember.run(function() {
-            click('.tt-suggestion:nth-child(' + suggestionIndex + ')');
+            click('.typeahead-suggestion:nth-child(' + suggestionIndex + ')');
         });
 
         return app.testHelpers.wait();


### PR DESCRIPTION
The class selector for finding selections is not consistent with the one used in (default) suggestion templates.
This helper assumes the suggestions have a fixed class ('typeahead-suggestion').
Maybe passing the suggestion selector as a parameter is also an option... ?
