### PR TITLE
Fix binding of includeCss and includeTypeahead, add Fastboot support

### DIFF
--- a/blueprints/ember-aupac-typeahead/index.js
+++ b/blueprints/ember-aupac-typeahead/index.js
@@ -1,26 +1,21 @@
-function mergeConfig(obj1,obj2){
-  var obj3 = {};
-  for (var attrname in obj1) { obj3[attrname] = obj1[attrname]; }
-  for (var attrname in obj2) { obj3[attrname] = obj2[attrname]; }
-  return obj3;
-}
+/* eslint-env node */
+'use strict';
 
 module.exports = {
   normalizeEntityName: function() {},
   description: 'add corejs-typeahead to project',
 
-  afterInstall: function(app) {
+  include: function(app) {
+    this._super.included.apply(this, arguments);
 
-    var defaults = {
+    let defaults = {
       includeTypeahead: true
     };
 
-    var projectConfig = this.project.config(app.env);
-    var userConfig = projectConfig['ember-aupac-typeahead'] || defaults;
+    let userConfig = app.options['ember-aupac-typeahead'] || {};
+    let config = Object.assign(defaults, userConfig);
 
-    var config = mergeConfig(defaults, userConfig);
-
-    if (config.includeTypeahead) {
+    if (config.includeTypeahead && !process.env.EMBER_CLI_FASTBOOT) {
       return this.addBowerPackageToProject('corejs-typeahead', '~1.1.1');
     }
   }

--- a/index.js
+++ b/index.js
@@ -1,35 +1,25 @@
 /* eslint-env node */
 'use strict';
 
-function mergeConfig(obj1,obj2){
-  var obj3 = {};
-  for (var attrname in obj1) { obj3[attrname] = obj1[attrname]; }
-  for (var attrname in obj2) { obj3[attrname] = obj2[attrname]; }
-  return obj3;
-}
-
 module.exports = {
   name: 'ember-aupac-typeahead',
-  included : function included(app) {
+  included: function(app) {
     this._super.included.apply(this, arguments);
 
-    var defaults = {
+    let defaults = {
       includeCss: true,
       includeTypeahead: true
     };
 
-    var projectConfig = this.project.config(app.env);
-    var userConfig = projectConfig['ember-aupac-typeahead'] || defaults;
-
-    var config = mergeConfig(defaults, userConfig);
+    let userConfig = app.options['ember-aupac-typeahead'] || {};
+    let config = Object.assign(defaults, userConfig);
 
     if(config.includeCss) {
       app.import('vendor/aupac-typeahead.css');
     }
 
-    if (config.includeTypeahead) {
+    if(config.includeTypeahead && !process.env.EMBER_CLI_FASTBOOT) {
       app.import(app.bowerDirectory + '/corejs-typeahead/dist/typeahead.jquery.min.js');
     }
-
   }
 };


### PR DESCRIPTION
I've made a few changes to the index.js + blueprint to tidy this a little bit with ES6 features, and added in the Fastboot flag so this now works with Ember Fastboot apps.

Key changes: 
- Refactor merge function to use Object.assign
- Add Fastboot check for including jquery
- Adjust the function to use the included hook
- Check against app.options instead of this.project.config, which wasn't working.