### PR TITLE
Prepare for ember-cli-fastboot 1.0 build format

### DIFF
--- a/blueprints/ember-aupac-typeahead/index.js
+++ b/blueprints/ember-aupac-typeahead/index.js
@@ -15,7 +15,7 @@ module.exports = {
     let userConfig = app.options['ember-aupac-typeahead'] || {};
     let config = Object.assign(defaults, userConfig);
 
-    if (config.includeTypeahead && !process.env.EMBER_CLI_FASTBOOT) {
+    if (config.includeTypeahead) {
       return this.addBowerPackageToProject('corejs-typeahead', '~1.1.1');
     }
   }

--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,10 @@
     "pretender": "~1.1.0",
     "Faker": "~3.1.0",
     "bootstrap": "~3.3.5",
-    "corejs-typeahead": "~1.1.1"
+    "corejs-typeahead": "~1.1.1",
+    "ember": "components/ember#lts-2-8"
+  },
+  "resolutions": {
+    "ember": "lts-2-8"
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,10 @@
 /* eslint-env node */
 'use strict';
+const fs = require('fs');
+
+const Funnel = require('broccoli-funnel');
+const map = require('broccoli-stew').map;
+const mergeTrees = require('broccoli-merge-trees');
 
 module.exports = {
   name: 'ember-aupac-typeahead',
@@ -18,8 +23,24 @@ module.exports = {
       app.import('vendor/aupac-typeahead.css');
     }
 
-    if(config.includeTypeahead && !process.env.EMBER_CLI_FASTBOOT) {
-      app.import(app.bowerDirectory + '/corejs-typeahead/dist/typeahead.jquery.min.js');
+    if(config.includeTypeahead) {
+      app.import('vendor/typeahead.jquery.min.js');
+    }
+  },
+  treeForVendor: function(defaultTree) {
+    const app = this._findHost();
+    const assetPath =__dirname + '/' + app.bowerDirectory + '/corejs-typeahead/dist/';
+
+    if (fs.existsSync(assetPath)) {
+      debugger;
+      let jquerymin = new Funnel(assetPath, {
+        files: ['typeahead.jquery.min.js']});
+      jquerymin = map(jquerymin,
+        (content) => `if (typeof FastBoot === 'undefined') { ${content} }`);
+      return new mergeTrees([defaultTree, jquerymin]);
+    } else {
+      debugger;
+      return defaultTree;
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -32,14 +32,12 @@ module.exports = {
     const assetPath =__dirname + '/' + app.bowerDirectory + '/corejs-typeahead/dist/';
 
     if (fs.existsSync(assetPath)) {
-      debugger;
       let jquerymin = new Funnel(assetPath, {
         files: ['typeahead.jquery.min.js']});
       jquerymin = map(jquerymin,
         (content) => `if (typeof FastBoot === 'undefined') { ${content} }`);
       return new mergeTrees([defaultTree, jquerymin]);
     } else {
-      debugger;
       return defaultTree;
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
-    "ember-cli-htmlbars": "^1.1.1"
+    "ember-cli-htmlbars": "^2.0.1"
   },
   "bugs": {
     "url": "https://github.com/aupac/ember-aupac-typeahead/issues"
@@ -29,10 +29,13 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
+    "broccoli-funnel": "^1.2.0",
+    "broccoli-merge-trees": "^2.0.0",
+    "broccoli-stew": "^1.5.0",
     "ember-ajax": "^2.4.1",
     "ember-aupac-control": "1.0.3",
     "ember-aupac-mocks": "1.0.1",
-    "ember-cli": "2.12.1",
+    "ember-cli": "2.14.0-beta.2",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.3",
@@ -50,7 +53,6 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^2.0.3",
-    "ember-source": "^2.12.0",
     "ember-validations": "git://github.com/DockYard/ember-validations.git#5502c4c",
     "loader.js": "^4.2.3"
   },


### PR DESCRIPTION
Hi there, ember-cli-fastboot 1.0 will have backwards incompatible changes. Please see doc here https://gist.github.com/kratiahuja/d22de0fb1660cf0ef58f07a6bcbf1a1c. The motivation for this change is documented here ember-fastboot/ember-cli-fastboot#387
The environment variable EMBER_CLI_FASTBOOTdoesn't exists any more in ember-cli-fastboot 1.0 build. I made the changes here, however 2  tests for this repo are already failing without my change.  I fixed one by upgrade ember-cli-htmlbars. I don't have enough context. Could you please verify on your side with proper use cases?
