### PR TITLE
Fix: Action not called when value cleared out

### DIFF
--- a/addon/components/aupac-ember-data-typeahead.js
+++ b/addon/components/aupac-ember-data-typeahead.js
@@ -58,7 +58,7 @@ export default AupacTypeahead.extend({
 
     if (this.get('allowFreeInput')) {
       const displayKey = this.get('displayKey');
-      const displayValue = typeOf(model) === 'instance' ? model.get(displayKey) : ''
+      const displayValue = typeOf(model) === 'instance' ? model.get(displayKey) : undefined
       const value = this.get('_typeahead').typeahead('val');
 
       if (displayValue !== value) {


### PR DESCRIPTION
On the TypeAhead Date if not model is selected then display value should be undefined rather then an empty string `''` to get the action to be called. Fixes #62 