### PR TITLE
on up/down arrow, set the input only if data.val is a string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2415,9 +2415,7 @@
       "dev": true
     },
     "corejs-typeahead": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/corejs-typeahead/-/corejs-typeahead-1.2.1.tgz",
-      "integrity": "sha1-NFqK/mZMxJQHW1m2R3eAfws/Eys=",
+      "version": "git+https://github.com/Gridium/typeahead.js.git#249b7acfcab0044cef46b609e1b89d55e1f0b48d",
       "requires": {
         "jquery": "3.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^2.0.0",
-    "corejs-typeahead": "^1.2.1",
+    "corejs-typeahead": "git+https://github.com/Gridium/typeahead.js.git#arrow-object-data-dist",
     "ember-aupac-control": "^1.2.0",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.1"


### PR DESCRIPTION
I'm not sure what to do with this fix; it looks like corejavascript/typeahead is no longer maintained (see Mar 28 2018 comment on https://github.com/corejavascript/typeahead.js/pull/181).

This uses my forked version of corejavascript/typeahead.js with an update to leaves input unchanged when navigating through object results with arrow keys: see https://github.com/corejavascript/typeahead.js/pull/184
